### PR TITLE
v5.3.0

### DIFF
--- a/sbb_data/migrations/2021-01-05-192607_create_robot_groups/up.sql
+++ b/sbb_data/migrations/2021-01-05-192607_create_robot_groups/up.sql
@@ -2,7 +2,7 @@ create table robot_groups (
     id               serial8 primary key,
     tweet_id         int8 not null unique,
     tweet_time       timestamp with time zone not null,
-    image_url        text,
+    image_url        text not null,
     body             text not null,
     alt              text,
     content_warning  text

--- a/sbb_data/migrations/2021-01-05-193905_create_robots/up.sql
+++ b/sbb_data/migrations/2021-01-05-193905_create_robots/up.sql
@@ -1,6 +1,6 @@
 create table robots (
     id              serial8 primary key,
-    robot_group_id  int8 not null references robot_groups (id),
+    robot_group_id  int8 not null references robot_groups (id) on delete cascade,
     robot_number    int4 not null,
     prefix          text not null,
     suffix          text not null,

--- a/sbb_data/migrations/2021-01-05-194842_create_tags/up.sql
+++ b/sbb_data/migrations/2021-01-05-194842_create_tags/up.sql
@@ -1,5 +1,5 @@
 create table tags (
     id              serial8 primary key,
-    robot_group_id  int8 not null references robot_groups (id),
+    robot_group_id  int8 not null references robot_groups (id) on delete cascade,
     tag             text not null
 );

--- a/sbb_data/migrations/2021-01-05-195234_create_past_dailies/up.sql
+++ b/sbb_data/migrations/2021-01-05-195234_create_past_dailies/up.sql
@@ -1,5 +1,5 @@
 create table past_dailies (
     id         serial8 primary key,
-    robot_id   int8 not null references robots (id),
+    robot_id   int8 not null references robots (id) on delete cascade,
     posted_on  date not null
 );

--- a/sbb_data/migrations/2021-01-05-195558_create_scheduled_dailies/up.sql
+++ b/sbb_data/migrations/2021-01-05-195558_create_scheduled_dailies/up.sql
@@ -1,5 +1,5 @@
 create table scheduled_dailies (
     id        serial8 primary key,
-    robot_id  int8 not null references robots (id),
+    robot_id  int8 not null references robots (id) on delete cascade,
     post_on   date not null unique
 );

--- a/sbb_data/migrations/2021-01-28-131314_create_tagged_markers/up.sql
+++ b/sbb_data/migrations/2021-01-28-131314_create_tagged_markers/up.sql
@@ -1,4 +1,4 @@
 create table tagged_markers (
-    robot_group_id  int8 primary key references robot_groups (id),
+    robot_group_id  int8 primary key references robot_groups (id) on delete cascade,
     tagged_at       timestamp with time zone not null default CURRENT_TIMESTAMP
 );

--- a/sbb_data/src/model.rs
+++ b/sbb_data/src/model.rs
@@ -7,7 +7,7 @@ pub struct RobotGroup {
     pub id: i64,
     pub tweet_id: i64,
     pub tweet_time: DateTime<Utc>,
-    pub image_url: Option<String>,
+    pub image_url: String,
     pub body: String,
     pub alt: Option<String>,
     pub content_warning: Option<String>,

--- a/sbb_data/src/new.rs
+++ b/sbb_data/src/new.rs
@@ -7,7 +7,7 @@ use chrono::prelude::*;
 pub struct NewRobotGroup<'a> {
     pub tweet_id: i64, //Cast u64 to i64 to obtain this, then cast back to u64 when retrieving the group
     pub tweet_time: DateTime<Utc>,
-    pub image_url: Option<&'a str>,
+    pub image_url: &'a str,
     pub body: &'a str,
     pub alt: Option<&'a str>,
     pub content_warning: Option<&'a str>,

--- a/sbb_data/src/schema.rs
+++ b/sbb_data/src/schema.rs
@@ -24,7 +24,7 @@ table! {
         id -> Int8,
         tweet_id -> Int8,
         tweet_time -> Timestamptz,
-        image_url -> Nullable<Text>,
+        image_url -> Text,
         body -> Text,
         alt -> Nullable<Text>,
         content_warning -> Nullable<Text>,

--- a/sbb_parse/src/twitter.rs
+++ b/sbb_parse/src/twitter.rs
@@ -17,18 +17,18 @@ pub fn parse_tweet<F, T>(tweet: &Tweet, handler: F) -> Option<T> where F: Fn(New
         .filter(|&media| {
             media.media_type == "photo" || media.media_type == "animated_gif" || media.media_type == "video"
         })
-        .next();
+        .next()?;
 
-    let image_url = image.map(|image| image.media_url.as_str());
+    let image_url = image.media_url.as_str();
 
-    let alt = image.and_then(|image| {
+    let alt = {
         let alt = image.alt.trim();
         if alt.is_empty() {
             None
         } else {
             Some(alt)
         }
-    });
+    };
 
     let group = NewRobotGroup{
         tweet_id: tweet.id as i64,


### PR DESCRIPTION
- Cascade delete for most foreign key relationships
- Image URL is no longer nullable
- No longer index robot tweets without at least one media attachment that is one of:
  - photo
  - animated_gif
  - video